### PR TITLE
chore: bump version number to 1.7.6

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -4,7 +4,7 @@ const config = generateDeploymentConfig("plh_kids_teens_za");
 
 config.git = {
   content_repo: "https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-za-content.git",
-  content_tag_latest: "1.7.5",
+  content_tag_latest: "1.7.6",
 };
 
 config.google_drive.sheets_folders = [


### PR DESCRIPTION
Bumps content version number to `1.7.6`. This is required because, in debugging the automated ios-release action, I already uploaded a build using v1.7.5, and now need to publish another build (the version number cannot be the same, as seen in [this failing action run](https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-za-content/actions/runs/23001076058)).